### PR TITLE
Prevent underflow in keys_currently_down

### DIFF
--- a/i8042_debounce.c
+++ b/i8042_debounce.c
@@ -49,7 +49,9 @@ static bool i8042_debounce_filter(
 	if (data & 0x80) {
 		// This is a keyup event
 		key->is_down = false;
-		keys_currently_down--;
+		if (likely(keys_currently_down)) {
+			keys_currently_down--;
+		}
 
 		key->jiffies_last_keyup = jiffies;
 		if (key->block_next_keyup) {


### PR DESCRIPTION
When the sytem resumes after a period of sleep, a series of ACK scancodes (`0xfa`) and a keyboard ID sequence (`0xab 0x41`) pass through this filter. I observed the following 13 bytes:
```
fa ab 41 fa fa fa fa fa fa fa fa fa fa
```
Because they have the high bit set, the `0xfa` and `0xab` bytes are mistaken for keyups, causing `keys_currently_down` to be decremented past zero. Because `keys_currently_down` is unsigned, it wraps around to 244. As a result, all subsequent debounce decisions are based on the wrong
threshold, using 55ms rather than 40ms.

Distinguishing ACK and keyboard ID scancodes from actual keyup/keydown events is a more involved fix, but preventing `keys_currently_down` underflow is simple.